### PR TITLE
Don't die from git repo errors

### DIFF
--- a/ami/install-tools.sh
+++ b/ami/install-tools.sh
@@ -57,5 +57,5 @@ TOOLS_URL_LIST=$(grep github.com README.md |awk -F '[' '{ print $2 }'| awk -F ']
 sudo mkdir -p /opt/arsenal
 cd /opt/arsenal
 for tool_url in $TOOLS_URL_LIST; do
-  sudo git clone $tool_url
+  sudo git clone $tool_url || sudo git clone $tool_url $(basename $tool_url)-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 done

--- a/ami/install-tools.sh
+++ b/ami/install-tools.sh
@@ -57,5 +57,7 @@ TOOLS_URL_LIST=$(grep github.com README.md |awk -F '[' '{ print $2 }'| awk -F ']
 sudo mkdir -p /opt/arsenal
 cd /opt/arsenal
 for tool_url in $TOOLS_URL_LIST; do
-  sudo git clone $tool_url || sudo git clone $tool_url $(basename $tool_url)-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+  sudo git clone $tool_url || \
+    sudo git clone $tool_url $(basename $tool_url)-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1) || \
+    :
 done


### PR DESCRIPTION
Changes for when `git clone` fails:

1. There are two projects called `slurp`. Cloning the second one obviously fails. So if a clone fails, try again but with 8 random characters appended to the directory name.
2. Also, should the repo no longer exist, we may not want to die completely, so allow a fall through to the noop of `:`
